### PR TITLE
gorm.DB 1.0 has breaking changes: gorm.Open return type *gorm.DB inst…

### DIFF
--- a/ecs_state.go
+++ b/ecs_state.go
@@ -23,7 +23,7 @@ import (
 // The State object provides methods to synchronize and query the state of the ECS cluster.
 type State struct {
 	clusterName string
-	db          gorm.DB
+	db          *gorm.DB
 	ecs_client  *ecs.ECS
 	log         Logger
 }
@@ -49,7 +49,7 @@ func Initialize(clusterName string, ecs_client *ecs.ECS, logger Logger) *State {
 
 // Provides direct access to the database through gorm to allow more advanced queries against state.
 func (state *State) DB() *gorm.DB {
-	return &state.db
+	return state.db
 }
 
 // Will parse and log any AWS errors received while contacting ECS.


### PR DESCRIPTION
gorm 1.0 release changed gorm.Open to return type *gorm.DB instead of gorm.DB.  This PR updates the type to reflect what is being returned.  This should resolve issue #3 
- http://jinzhu.me/gorm/changelog.html
